### PR TITLE
Pass `CoroutineScope` to ran `block`s in `Execution.async` and `Execution.delayed`

### DIFF
--- a/Toolkt/src/main/java/com/reco1l/toolkt/kotlin/Execution.kt
+++ b/Toolkt/src/main/java/com/reco1l/toolkt/kotlin/Execution.kt
@@ -2,6 +2,7 @@
 
 package com.reco1l.toolkt.kotlin
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
@@ -10,14 +11,14 @@ import kotlinx.coroutines.launch
 /**
  * Run a task on asynchronous using global scope.
  */
-fun async(block: () -> Unit) = GlobalScope.launch {
+fun async(block: CoroutineScope.() -> Unit) = GlobalScope.launch {
     block()
 }
 
 /**
  * Run a delayed task on asynchronous using global scope.
  */
-fun delayed(time: Long, block: () -> Unit) = GlobalScope.launch {
+fun delayed(time: Long, block: CoroutineScope.() -> Unit) = GlobalScope.launch {
     delay(time)
     block()
 }


### PR DESCRIPTION
Adds support for accessing `CoroutineScope` in passed functions.